### PR TITLE
Breaking quality check issue fixed

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ codecov==2.1.12
     # via -r requirements/ci.in
 coverage==6.4.4
     # via codecov
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via
@@ -44,5 +44,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.12
     # via requests
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -19,6 +19,8 @@ Django<4.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
 
+# setuptools==60.0 had breaking changes and busted several service's pipeline.
+# Details can be found here: https://github.com/pypa/setuptools/issues/2940
 setuptools<60
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.5.2
     # via django
-astroid==2.11.7
+astroid==2.12.5
     # via
     #   pylint
     #   pylint-celery
@@ -44,7 +44,7 @@ diff-cover==6.5.1
     # via -r requirements/dev.in
 dill==0.3.5.1
     # via pylint
-distlib==0.3.5
+distlib==0.3.6
     # via
     #   caniusepython3
     #   virtualenv
@@ -61,7 +61,7 @@ django-config-models==2.3.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==2.7.0
+django-waffle==3.0.0
     # via edx-django-utils
 djangorestframework==3.13.1
     # via django-config-models
@@ -142,7 +142,7 @@ pygments==2.13.0
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.14.5
+pylint==2.15.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -223,7 +223,7 @@ urllib3==1.26.12
     # via
     #   requests
     #   twine
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.11.7
+astroid==2.12.5
     # via
     #   pylint
     #   pylint-celery
@@ -27,7 +27,7 @@ code-annotations==1.3.0
     # via edx-lint
 dill==0.3.5.1
     # via pylint
-distlib==0.3.5
+distlib==0.3.6
     # via caniusepython3
 edx-lint==5.2.4
     # via -r requirements/quality.in
@@ -55,7 +55,7 @@ pycodestyle==2.9.1
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.14.5
+pylint==2.15.0
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ django-config-models==2.3.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==2.7.0
+django-waffle==3.0.0
     # via edx-django-utils
 djangorestframework==3.13.1
     # via django-config-models

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 [testenv:quality]
 setenv = 
     DJANGO_SETTINGS_MODULE=test_settings
+    PYTHONPATH = .
 whitelist_externals = 
     make
     rm


### PR DESCRIPTION
Quality tests were breaking due to the upgrade in package `virtualenv` from `virtualenv==20.16.3` to `virtualenv==20.16.4`.
So, I've fixed the issue by explicitly passing the Path ans variable to test_settings inside `tox.ini` as following:
`setenv = 
    DJANGO_SETTINGS_MODULE=test_settings
    PYTHONPATH = .`

**Helping/Solution site:**
https://tox.wiki/en/latest/example/basic.html#a-simple-tox-ini-default-environments